### PR TITLE
fix: collision with multiple "space" keys

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -338,7 +338,7 @@
         "antiquetarotcard"
     ],
     "stylish": [
-        "space",
+        "sdxlspace",
         "building",
         "animal",
         "futurefashion",

--- a/styles.json
+++ b/styles.json
@@ -194,7 +194,7 @@
         "steps": 50,
         "cfg_scale": 5
     },
-    "space": {
+    "sdxlspace": {
         "prompt": "{p}, by Andrew McCarthy, Navaneeth Unnikrishnan, Manuel Dietrich, photo realistic, 8 k, cinematic lighting, hd, atmospheric, hyperdetailed, trending on artstation, deviantart, photography, glow effect###{np}",
         "model": "SDXL_beta::stability.ai#6901",
         "sampler_name": "k_dpmpp_sde",
@@ -1386,7 +1386,7 @@
         "prompt": "{p}, IconsMi{np}",
         "model": "App Icon Diffusion"
     },
-    "deep_space": {
+    "space": {
         "prompt": "{p}, jwst{np}",
         "model": "JWST Deep Space Diffusion"
     },

--- a/styles.json
+++ b/styles.json
@@ -1386,7 +1386,7 @@
         "prompt": "{p}, IconsMi{np}",
         "model": "App Icon Diffusion"
     },
-    "space": {
+    "deep_space": {
         "prompt": "{p}, jwst{np}",
         "model": "JWST Deep Space Diffusion"
     },


### PR DESCRIPTION
renames "space" -> deep_space for jwst deep space, as another key of "space" already exists for SDXL